### PR TITLE
[fix]error message garble

### DIFF
--- a/public_html/lib-common.php
+++ b/public_html/lib-common.php
@@ -7776,7 +7776,7 @@ function COM_handleError($errno, $errstr, $errfile = '', $errline = 0, $errconte
             if (!empty($_CONF['site_name'])) {
                 $title = $_CONF['site_name'] . ' - ' . $title;
             }
-            echo "<html><head><title>$title</title></head>\n<body>\n";
+            echo "<html><head><meta charset=\"".$_CONF['default_charset']."\"><title>$title</title></head>\n<body>\n";
 
             echo '<h1>An error has occurred:</h1>';
             if ($_CONF['rootdebug']) {


### PR DESCRIPTION
In Japan, error site always garbled.
So added charset.