### PR TITLE
[fix] PNG image transparency can't be preserved

### DIFF
--- a/system/classes/upload.class.php
+++ b/system/classes/upload.class.php
@@ -700,7 +700,8 @@ class upload
                     $image_dest = @imagecreatefromjpeg ($filename);
                     unlink ($filename);
                 }
-
+								imagealphablending( $image_dest, false );
+								imagesavealpha( $image_dest, true );
                 imagecopyresampled($image_dest, $image_source, 0, 0, 0, 0,
                                    $newwidth, $newheight, $imageInfo['width'],
                                    $imageInfo['height']);


### PR DESCRIPTION
PNG image transparency can't be preserved.

```
imagealphablending( $image_dest, false );
imagesavealpha( $image_dest, true );
```
did it for me. Thanks 

see more
http://stackoverflow.com/questions/32243/can-png-image-transparency-be-preserved-when-using-phps-gdlib-imagecopyresample
