### PR TITLE
Fixed that HTML close tag becomes illegal in related information of article

### DIFF
--- a/system/lib-article.php
+++ b/system/lib-article.php
@@ -702,7 +702,7 @@ function STORY_extractLinks($fulltext, $maxlength = 26)
 
         // if link is too long, shorten it and add ... at the end
         if (($maxlength > 0) && (MBYTE_strlen($matches[2][$i]) > $maxlength)) {
-            $matches[2][$i] = substr($matches[2][$i], 0, $maxlength - 3) . '...';
+            $matches[2][$i] = MBYTE_substr($matches[2][$i], 0, $maxlength - 3) . '...';
         }
 
         $rel[] = '<a href="' . $matches[1][$i] . '">'


### PR DESCRIPTION
Fixed incorrect closing tag of HTML by cutting processing when the character string is multibyte and 26 characters or more in related information of the article