### PR TITLE
Minor fixes for the German admin/install language file

### DIFF
--- a/public_html/admin/install/language/_list.php
+++ b/public_html/admin/install/language/_list.php
@@ -31,7 +31,7 @@ return [
         'langCode' => 'de',
         'langName' => 'Deutsch',
         'english'  => 'German',
-        'charset'  => 'iso-8859-15',
+        'charset'  => 'utf-8',
     ],
     'hebrew_utf-8.php'              => [
         'langCode' => 'he',

--- a/public_html/admin/install/language/german_utf-8.php
+++ b/public_html/admin/install/language/german_utf-8.php
@@ -499,7 +499,6 @@ $LANG_LABEL = array(
     'site_admin_url' => $LANG_INSTALL[47],
     'site_mail'      => $LANG_INSTALL[48],
     'noreply_mail'   => $LANG_INSTALL[49],
-    'utf8'           => $LANG_INSTALL[92],
     'charactersets'  => $LANG_INSTALL[123],
     'migrate_file'   => $LANG_MIGRATE[6],
     'plugin_upload'  => $LANG_PLUGINS[10]

--- a/public_html/admin/install/language/german_utf-8.php
+++ b/public_html/admin/install/language/german_utf-8.php
@@ -500,7 +500,7 @@ $LANG_LABEL = array(
     'site_mail'      => $LANG_INSTALL[48],
     'noreply_mail'   => $LANG_INSTALL[49],
     'utf8'           => $LANG_INSTALL[92],
-	'charactersets'  => $LANG_INSTALL[123],
+    'charactersets'  => $LANG_INSTALL[123],
     'migrate_file'   => $LANG_MIGRATE[6],
     'plugin_upload'  => $LANG_PLUGINS[10]
 );


### PR DESCRIPTION
I have virtually no idea anymore what's going on in the Geeklog code, but I ran into these 2 minor issues trying to get GL to work with PHP 8.1.

The entry for the German admin/install language file in _list.php says it's character set iso-8859-15, but the file name says it's UTF-8. The file contains UTF-8 characters, so the ISO entry seems to be wrong.

And in the language file itself, there's a reference to $LANG_INSTALL[92] which doesn't exist and caused a warning upon install. Looks like it's not needed, so I removed it.

Actually, that $LANG_INSTALL[92] is referenced in some of the other language files as well, but not in the English ones. If my assumption is correct, then those should be fixed, too.