### PR TITLE
Prevent "mkdir(): File exists" warning on plugin import (PHP 8, v2.2.2)

### DIFF
--- a/public_html/lib-common.php
+++ b/public_html/lib-common.php
@@ -8457,9 +8457,9 @@ function COM_handleError($errNo, $errStr, $errFile = '', $errLine = 0, $errConte
 {
     global $_CONF, $_USER, $LANG01;
 
-    // Handle @ operator
-    if (error_reporting() == 0) {
-        return;
+    // Respect the @ operator and the current error reporting mask
+    if ((error_reporting() & $errNo) === 0) {
+        return true;
     }
 
     $hasPHP8 = version_compare(PHP_VERSION, '8.0.0', '>=');


### PR DESCRIPTION
Fixes #1145

## Summary

This updates `COM_handleError()` so that it respects the `@` operator and the current `error_reporting()` mask on PHP 8.

## Problem

The current error handler checks:

```php
if (error_reporting() == 0) {
    return;
}
```

On PHP 8, `error_reporting()` does not necessarily return `0` inside an error handler when an error is suppressed with `@`.

This causes suppressed warnings such as:

```php
@mkdir($outdir, 0777, true);
```

and:

```php
@file_get_contents($plugin_inst);
```

to be displayed to Root users and to interrupt plugin uploads.

## Change

The handler now checks whether the specific error level is enabled in the current error-reporting mask:

```php
if ((error_reporting() & $errNo) === 0) {
    return true;
}
```

## Tested with

- Geeklog 2.2.2
- PHP 8.1
- PHP 8.3
- ZIP plugin upload
- TAR plugin upload

After applying this change, suppressed warnings are ignored while unsuppressed warnings continue to be handled normally.
