### PR TITLE
Fix XMLSitemap IndexNow notifications

### DIFF
--- a/plugins/xmlsitemap/functions.inc
+++ b/plugins/xmlsitemap/functions.inc
@@ -476,8 +476,8 @@ function plugin_itemsaved_xmlsitemap($id, $type, $old_id, $sub_type)
 		XMLSMAP_update($type);
     }
 	
-	// Ping IndexNow for changed url. For new, updated, and delete
-	if ($_XMLSMAP_CONF['indexnow']) {
+	// Only notify IndexNow when the saved item is publicly accessible.
+	if (!empty($_XMLSMAP_CONF['indexnow']) && !empty($newItem)) {
 		$sitemap->submitURL($url);
 	}
 }
@@ -541,6 +541,11 @@ function plugin_itemdeleted_xmlsitemap($id, $type, $sub_type)
         if (!$result) {
             XMLSMAP_update($type);
         }
+
+		// Notify IndexNow so search engines can remove the deleted URL.
+		if (!empty($_XMLSMAP_CONF['indexnow'])) {
+			$sitemap->submitURL($oldUrl);
+		}
     }
 }
 


### PR DESCRIPTION
## Summary
- notify IndexNow only when a saved item is publicly accessible
- notify IndexNow after an item is deleted so search engines can remove the URL
- handle a missing or disabled IndexNow setting safely

Fixes #1174
Fixes #1175

## Validation
- `git diff --check`
- PHP lint and PHPUnit were not run because PHP/PHPUnit are unavailable in the local environment