### PR TITLE
Fix static page deletion when comment library is not loaded

### DIFF
--- a/plugins/staticpages/services.inc.php
+++ b/plugins/staticpages/services.inc.php
@@ -803,6 +803,7 @@ function service_delete_staticpages($args, &$output, &$svc_msg)
     // Delete page
     DB_delete($_TABLES['staticpage'], 'sp_id', $sp_id);
 	
+    require_once $_CONF['path_system'] . 'lib-comment.php';
 	CMT_deleteComment('', $sp_id, STATICPAGES_PLUGIN_NAME, false);
 
     TOPIC_deleteTopicAssignments('staticpages', $sp_id);


### PR DESCRIPTION
Fix static page deletion by ensuring `lib-comment.php` is loaded before calling `CMT_deleteComment()`.

This prevents the deletion request from failing after the static page has already been removed.

Fixes #1144.
